### PR TITLE
Don't set bold style for Directory group

### DIFF
--- a/lua/material.lua
+++ b/lua/material.lua
@@ -227,7 +227,7 @@ Group.new('ColorColumn', c.fg3, c.bg, no) --  used for the columns set with 'col
 Group.new('Conceal', c.blue, c.bg, no) -- placeholder characters substituted for concealed text (see 'conceallevel')
 Group.new('Cursor', c.none, c.none, r) -- the character under the cursor
 Group.new('CursorIM', c.fg, c.none, r) -- like Cursor, but used when in IME mode
-Group.new('Directory', c.blue, c.none, b) -- directory names (and other special names in listings)
+Group.new('Directory', c.blue, c.none, no) -- directory names (and other special names in listings)
 Group.new('DiffAdd', c.green, c.none, r) -- diff mode: Added line
 Group.new('DiffChange', c.orange, c.none, r) --  diff mode: Changed line
 Group.new('DiffDelete', c.red, c.none, r) -- diff mode: Deleted line


### PR DESCRIPTION
For consistency wit NvimTree (vim-dirvish uses Directory group to highlight folder name).
Before | After
:-: | :-:
![Screen Shot 2021-04-17 at 8 49 20 PM](https://user-images.githubusercontent.com/17645203/115115406-84782100-9fbe-11eb-9419-062a19caabe9.png) | ![Screen Shot 2021-04-17 at 8 49 44 PM](https://user-images.githubusercontent.com/17645203/115115381-732f1480-9fbe-11eb-97d0-342d46313891.png)
