### PR TITLE
adjust telescope selection coloring

### DIFF
--- a/lua/material/theme.lua
+++ b/lua/material/theme.lua
@@ -376,7 +376,7 @@ theme.loadPlugins = function()
         TelescopeResultsBorder =                { fg = material.purple },
         TelescopePreviewBorder =                { fg = material.green },
         TelescopeSelectionCaret =               { fg = material.purple },
-        TelescopeSelection =                    { fg = material.purple },
+        TelescopeSelection =                    { fg = material.fg, bg = material.selection},
         TelescopeMatching =                     { fg = material.cyan },
         TelescopeNormal =                       { fg = material.fg, bg = material.float },
 


### PR DESCRIPTION
This changes the telescope selection hightlighting from purple to fg and also sets the background color to selection in order to improve the visibility of the currently selected item in telescope.