### PR TITLE
fix: setting terminal colors

### DIFF
--- a/lua/material/util.lua
+++ b/lua/material/util.lua
@@ -49,9 +49,9 @@ function util.load()
         local plugins = material.loadPlugins()
         local lsp = material.loadLSP()
 
-		if vim.g.material_disable_teminal == false then
-			material.loadTerminal()
-		end
+        if vim.g.material_disable_terminal == false then
+          material.loadTerminal()
+        end
 
         for group, colors in pairs(plugins) do
             util.highlight(group, colors)


### PR DESCRIPTION
The terminal color disable option introduced with commit 3b7f292911feb5d983bc27916d4cd8ece9b39d34 contained a typo in the code reading the new setting variable. This resulted in the terminal colors never being set.

This fixes this issue and adjusts the indention of the new check to the rest of the file.