### PR TITLE
Add lsp highlight for neovim 0.6.x

### DIFF
--- a/lua/material/theme.lua
+++ b/lua/material/theme.lua
@@ -343,6 +343,23 @@ theme.loadLSP = function ()
 		LspReferenceText =                      { fg = material.accent, bg = material.highlight }, -- used for highlighting "text" references
 		LspReferenceRead =                      { fg = material.accent, bg = material.highlight }, -- used for highlighting "read" references
 		LspReferenceWrite =                     { fg = material.accent, bg = material.highlight }, -- used for highlighting "write" references
+
+		DiagnosticVirtualTextWarn  = { link = "LspDiagnosticsVirtualTextWarning" },
+		DiagnosticUnderlineWarn    = { link = "LspDiagnosticsUnderlineWarning" },
+		DiagnosticFloatingWarn     = { link = "LspDiagnosticsFloatingWarning" },
+		DiagnosticSignWarn         = { link = "LspDiagnosticsSignWarning" },
+		DiagnosticVirtualTextError = { link = "LspDiagnosticsVirtualTextError" },
+		DiagnosticUnderlineError   = { link = "LspDiagnosticsUnderlineError" },
+		DiagnosticFloatingError    = { link = "LspDiagnosticsFloatingError" },
+		DiagnosticSignError        = { link = "LspDiagnosticsSignError" },
+		DiagnosticVirtualTextInfo  = { link = "LspDiagnosticsVirtualTextInformation" },
+		DiagnosticUnderlineInfo    = { link = "LspDiagnosticsUnderlineInformation" },
+		DiagnosticFloatingInfo     = { link = "LspDiagnosticsFloatingInformation" },
+		DiagnosticSignInfo         = { link = "LspDiagnosticsSignInformation" },
+		DiagnosticVirtualTextHint  = { link = "LspDiagnosticsVirtualTextHint" },
+		DiagnosticUnderlineHint    = { link = "LspDiagnosticsUnderlineHint" },
+		DiagnosticFloatingHint     = { link = "LspDiagnosticsFloatingHint" },
+		DiagnosticSignHint         = { link = "LspDiagnosticsSignHint" },
 	}
 
 	return lsp


### PR DESCRIPTION
Since with the arrival of nvim 0.6.x changes were made in the names of the hightlight groups of lsp, this PR presents a brief solution making links to the already defined colors of the LSP (that work in 0.5.x) with the new groups of colors of the version mentioned above.
An example of this follows:

- Before defining the groups in the colorscheme

![material_no_color](https://user-images.githubusercontent.com/65829671/134459384-ab31c8de-67f0-4ebf-8693-b59c8df99747.png)

- After defining the groups in the colorscheme

![Screenshot from 2021-09-22 19-05-02](https://user-images.githubusercontent.com/65829671/134459392-29781f1c-fb45-4562-a76c-359d2599ec0d.png)

New group names defined in nvim 0.6.x:

![preview](https://user-images.githubusercontent.com/65829671/134459501-ff6758c0-32c1-4e72-9ed9-22a94d70d79e.png)

when the groups are not defined, the colors are blank because in the theme loading function there is a "hightligt clear", which makes them disappear completely and they are not defined again.


Nvim version: 
```
NVIM v0.6.0-dev+313-g490e09c6d
Build type: Debug
LuaJIT 2.1.0-beta3
Compilation: /usr/bin/cc -DNVIM_TS_HAS_SET_MATCH_LIMIT -g -Wall -Wextra -pedantic -Wno-unused-parameter -Wstrict-prototypes -std=gnu99 -Wshadow -Wconversion -Wmissing-prototypes -Wimplicit-fallthrough -Wvla -fstack-protector-strong -fno-common -fdiagnostics-color=always -DINCLUDE_GENERATED_DECLARATIONS -D_GNU_SOURCE -DNVIM_MSGPACK_HAS_FLOAT32 -DNVIM_UNIBI_HAS_VAR_FROM -DMIN_LOG_LEVEL=1 -I/home/yagua/.local/sources/nvim/neovim-0-6-0/build/config -I/home/yagua/.local/sources/nvim/neovim-0-6-0/src -I/home/yagua/.local/sources/nvim/neovim-0-6-0/.deps/usr/include -I/usr/include -I/home/yagua/.local/sources/nvim/neovim-0-6-0/build/src/nvim/auto -I/home/yagua/.local/sources/nvim/neovim-0-6-0/build/include
Compiled by root@machine

Features: +acl +iconv +tui
See ":help feature-compile"

   system vimrc file: "$VIM/sysinit.vim"
  fall-back for $VIM: "/usr/local/share/nvim"

Run :checkhealth for more info
```
