### PR TITLE
fix syntax error in Def vals func (in README)

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ require('material').setup({
 		line_numbers = false, -- Enable contrast background for line numbers
 		sign_column = false, -- Enable contrast background for the sign column
 		cursor_line = false, -- Enable darker background for the cursor line
-		non_current_windows = false -- Enable darker background for non-current windows
+		non_current_windows = false, -- Enable darker background for non-current windows
 		popup_menu = false, -- Enable lighter background for the popup menu
 	},
 


### PR DESCRIPTION
The second to last option in the default values function doesnt include a comma.