### PR TITLE
added async_loading config option

### DIFF
--- a/lua/material/config.lua
+++ b/lua/material/config.lua
@@ -37,7 +37,9 @@ local defaults = {
 	lualine_style = 'default', -- Lualine style ( can be 'stealth' or 'default' )
 
 	custom_colors = {}, -- TODO: define custom colors
-	custom_highlights = {} -- define custom highlights
+	custom_highlights = {}, -- define custom highlights
+	
+  async_loading = true -- Enable asynchronous loading
 }
 
 Config.options = {}

--- a/lua/material/util.lua
+++ b/lua/material/util.lua
@@ -47,10 +47,11 @@ function util.load()
     vim.o.termguicolors = true
     vim.g.colors_name = "material"
 
-    -- Load plugins and lsp async
+  -- Load plugins and lsp
     local async
-    async = vim.loop.new_async(vim.schedule_wrap(function ()
-        -- imort tables for plugins and lsp
+
+    function plugins_and_lsp_loader()
+      -- imort tables for plugins and lsp
         local plugins = material.loadPlugins()
 
         if config.disable.term_colors == false then
@@ -58,19 +59,25 @@ function util.load()
         end
 
         for group, colors in pairs(plugins) do
-            util.highlight(group, colors)
+          util.highlight(group, colors)
         end
 
-		if type(config.custom_highlights) == 'table' then
-			for group, colors in pairs(config.custom_highlights) do
-				util.highlight(group, colors)
-			end
-		end
-		util.contrast()
-        async:close()
+        if type(config.custom_highlights) == 'table' then
+          for group, colors in pairs(config.custom_highlights) do
+            util.highlight(group, colors)
+          end
+        end
+        util.contrast()
 
-    end))
-
+        if (async) then async:close() end
+    end
+    
+    if (config.async_loading) then
+      async = vim.loop.new_async(vim.schedule_wrap(plugins_and_lsp_loader))
+    else
+      plugins_and_lsp_loader()
+    end
+    
     -- load base theme
     local editor = material.loadEditor()
     local syntax = material.loadSyntax()
@@ -93,7 +100,7 @@ function util.load()
 		util.highlight(group, colors)
 	end
 
-    async:send()
+    if (config.async_loading) then async:send() end
 end
 
 return util


### PR DESCRIPTION
this does what it says on the tin, I like this colorscheme however the async loading is messing up a lot of stuff on my setup (feline example below), figured it would be nice to have a toggle for it.

with `async_loading = true` (the default)
![image](https://user-images.githubusercontent.com/16624558/152701057-f9065cbe-b1ea-4b91-bed4-e8a4c7e283d1.png)

with `async_loading = false`
![image](https://user-images.githubusercontent.com/16624558/152701003-40660325-8425-48d4-9914-55e127ba2c68.png)

I've also noticed other people having issues related to this, namely #74 #50 #19

the `no-async` branch is outdated, this PR should eliminate the need for it anyways.