### PR TITLE
Add explicit support for 'mini.nvim'

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ added to NeoVim like built-in [LSP](https://github.com/neovim/nvim-lspconfig) an
     + [vim-sneak](https://github.com/justinmk/vim-sneak)
     + [nvim-dap](https://github.com/mfussenegger/nvim-dap)
     + [vim-illuminate](https://github.com/RRethy/vim-illuminate)
+    + [mini.nvim](https://github.com/echasnovski/mini.nvim)
 
 + Ability to change background on sidebar-like windows like Nvim-Tree, Packer, terminal etc.
 
@@ -207,6 +208,7 @@ require('material').setup({
 		hop = true,
 		indent_blankline = true,
 		nvim_illuminate = true,
+		mini = true,
 	}
 })
 ```

--- a/doc/material.nvim.txt
+++ b/doc/material.nvim.txt
@@ -189,6 +189,7 @@ This is an example of the setup function with the default values:
 			hop = true,
 			indent_blankline = true,
 			nvim_illuminate = true,
+			mini = true,
 		}
 	})
 

--- a/lua/material/config.lua
+++ b/lua/material/config.lua
@@ -60,6 +60,7 @@ local defaults = {
 		hop = true,
 		indent_blankline = true,
 		nvim_illuminate = true,
+		mini = true,
 	}
 }
 

--- a/lua/material/theme.lua
+++ b/lua/material/theme.lua
@@ -542,6 +542,60 @@ theme.loadPlugins = function()
 		plugins.illuminatedCurWord =					{ bg = colors.highight, underline = true }
 	end
 
+	if config.plugins.mini then
+
+		-- Mini
+		plugins.MiniCompletionActiveParameter = { underline = true }
+
+		plugins.MiniCursorword = { underline = true }
+		plugins.MiniCursorwordCurrent = { underline = true }
+
+		plugins.MiniIndentscopeSymbol = { fg = colors.cyan }
+		plugins.MiniIndentscopePrefix = { nocombine = true } -- Make it invisible
+
+		plugins.MiniJump = { fg = colors.bg, bg = colors.accent }
+
+		plugins.MiniJump2dSpot = { fg = colors.accent, bold = true, nocombine = true }
+
+		plugins.MiniStarterCurrent = { nocombine = true }
+		plugins.MiniStarterFooter = { fg = colors.green, italic = true }
+		plugins.MiniStarterHeader = { fg = colors.comments }
+		plugins.MiniStarterInactive = { link = "Comment" }
+		plugins.MiniStarterItem = { link = "Normal" }
+		plugins.MiniStarterItemBullet = { fg = colors.border }
+		plugins.MiniStarterItemPrefix = { fg = colors.yellow }
+		plugins.MiniStarterSection = {  fg = colors.cyan }
+		plugins.MiniStarterQuery = { fg = colors.paleblue }
+
+		plugins.MiniStatuslineDevinfo = { fg = colors.fg, bg = colors.active }
+		plugins.MiniStatuslineFileinfo = { fg = colors.fg, bg = colors.active }
+		plugins.MiniStatuslineFilename = { fg = colors.disabled, bg = colors.bg }
+		plugins.MiniStatuslineInactive = { fg = colors.disabled, bg = colors.bg }
+		plugins.MiniStatuslineModeCommand = { fg = colors.bg, bg = colors.yellow, bold = true }
+		plugins.MiniStatuslineModeInsert = { fg = colors.bg, bg = colors.green, bold = true }
+		plugins.MiniStatuslineModeNormal = { fg = colors.bg, bg = colors.accent, bold = true }
+		plugins.MiniStatuslineModeOther = { fg = colors.bg, bg = colors.cyan, bold = true }
+		plugins.MiniStatuslineModeReplace = { fg = colors.bg, bg = colors.red, bold = true }
+		plugins.MiniStatuslineModeVisual = { fg = colors.bg, bg = colors.purple, bold = true }
+
+		plugins.MiniSurround = { link = "IncSearch" }
+
+		plugins.MiniTablineCurrent = { fg = colors.bg, bg = colors.accent, bold = true }
+		plugins.MiniTablineFill = { link = "TabLineFill" }
+		plugins.MiniTablineHidden = { fg = colors.fg, bg = colors.bg }
+		plugins.MiniTablineModifiedCurrent = { fg = colors.accent, bg = colors.bg, bold = true }
+		plugins.MiniTablineModifiedHidden = { fg = colors.bg, bg = colors.fg }
+		plugins.MiniTablineModifiedVisible = { fg = colors.accent, bg = colors.bg }
+		plugins.MiniTablineTabpagesection = { fg = colors.title, bg = colors.selection, bold = true }
+		plugins.MiniTablineVisible = { fg = colors.bg, bg = colors.accent }
+
+		plugins.MiniTestEmphasis = { bold = true }
+		plugins.MiniTestFail = { fg = colors.red, bold = true }
+		plugins.MiniTestPass = { fg = colors.green, bold = true }
+
+		plugins.MiniTrailspace = { bg = colors.red }
+	end
+
 	return plugins
 
 end


### PR DESCRIPTION
Hi! I would like to add explicit support for [mini.nvim](https://github.com/echasnovski/mini.nvim).

Basic choices are taken from highlight groups to which 'mini.nvim' makes links by default or from analogous plugins.

Differences from default linked groups:
- 'mini.jump' is based on 'Skean'.
- 'mini.jump2d' is based on 'Hop'. Added `nocombine = true` for it to always be consistent (not become italic on italic text).
- 'mini.starter' is based on 'dashboard.lua' and personal choices:
    - `MiniStarterItemBullet` is as border.
    - `MiniStarterItemPrefix` and `MiniStarterQuery` are based on "warning" and "info" diagnostic colors to be opposite of each other.
    - `MiniStarterSection` is chosen to be visible.
- 'mini.statusline' is based on 'lualine/themes/material-nvim.lua' and personal choices:
    - All `MiniStatuslineMode*` have bold text to increase visibility.
    - `MiniStatuslineModeOther` is chosen to be different from others.
- 'mini.tabline' is based on explicit 'TabLine*' groups:
    - `MiniTablineCurrent` has bold font to be visually distinctive.
    - `MiniTablineVisible` is same as `MiniTablineCurrent` but not bold.
    - `MiniTablineModified*` groups have inverted `fg` and `bg` of their counterparts.
- 'mini.test' has red for fail and green for pass.
- 'mini.trailspace' has group with red background to draw attention.

Before:

https://user-images.githubusercontent.com/24854248/177943692-4c49f7fc-5c69-4af3-80dd-918e7f91b627.mp4

After:

https://user-images.githubusercontent.com/24854248/177943720-6fae3816-48c1-4045-b8df-e6627d6cea91.mp4
