### PR TITLE
fix: hide vertical split the best we can

### DIFF
--- a/lua/material/colors.lua
+++ b/lua/material/colors.lua
@@ -201,18 +201,22 @@ if type(config.custom_colors) == "table" then
 	end
 end
 
+-- Enable darker contrast for non-current windows
+-- This must be set first in order to affect border settings
+if config.contrast.non_current_windows == true then
+	colors.bg_nc = colors.bg_alt
+else
+	colors.bg_nc = colors.bg
+end
+
 -- Apply the disabled background setting
 if config.disable.background == true then
 	colors.bg = 'NONE'
 end
 
-if config.disable.borders == true then
-	colors.vsp = colors.bg
-end
-
 -- Disable borders
 if config.disable.borders == true then
-	colors.vsp = colors.bg
+	colors.vsp = colors.bg_nc
 else
 	colors.vsp = colors.border
 end
@@ -236,12 +240,6 @@ if config.contrast.cursor_line == true then
 	colors.bg_cur = colors.bg_alt
 else
 	colors.bg_cur = colors.active
-end
-
-if config.contrast.non_current_windows == true then
-	colors.bg_nc = colors.bg_alt
-else
-	colors.bg_nc = colors.bg
 end
 
 return colors

--- a/lua/material/theme.lua
+++ b/lua/material/theme.lua
@@ -138,7 +138,7 @@ theme.loadEditor = function ()
 		DashboardCenter =                       { fg = colors.accent },
 		DashboardFooter =                       { fg = colors.green, italic = true },
 
-		VertSplit =								{ fg = colors.vsp }, -- The column separating vertically split windows
+		VertSplit =								{ fg = colors.vsp, bg = colors.bg_nc }, -- The column separating vertically split windows
 		WinSeparator = 							{ fg = colors.vsp } -- Lines between window splits
 
 	}
@@ -162,7 +162,6 @@ theme.loadEditor = function ()
 		editor.PmenuSbar =				{ bg = colors.contrast } -- Popup menu: scrollbar.
 		editor.PmenuThumb =				{ bg = colors.selection } -- Popup menu: Thumb of the scrollbar.
 	end
-
 
 	return editor
 end
@@ -391,7 +390,7 @@ theme.loadPlugins = function()
 	-- NvimTree
 	if config.plugins.nvim_tree then
 		plugins.NvimTreeNormal =						{ fg = colors.fg, bg = colors.sidebar }
-		plugins.NvimTreeNormalNC =						{ link = "NvimTreeNormalNC" }
+		plugins.NvimTreeNormalNC =						{ link = "NvimTreeNormal" }
 		plugins.NvimTreeRootFolder =                    { fg = colors.accent }
 		plugins.NvimTreeFolderName=                     { fg = colors.blue, bold = true }
 		plugins.NvimTreeFolderIcon=                     { link = "NvimTreeFolderName" }


### PR DESCRIPTION
Vertical split is hardcoded to (neo)vim so there's no way getting rid of it short of making changes to the source code and compiling the binary yourself. But we can do our best hiding it by setting the bar color to match background so it blends in. If non_current_windows is set then the background needs to match non current background in order to blend in even if none of the vertical splits are selected.

Before:
![image](https://user-images.githubusercontent.com/2804020/193751245-3c1b1f27-1f0d-4e25-9005-69687ba97ff6.png)

After:
![image](https://user-images.githubusercontent.com/2804020/193751316-1817386d-1b30-42c2-b2f2-74bfbe707df0.png)

Somewhat related to #112.