### PR TITLE
fix: nvimtree non current background

### DIFF
--- a/lua/material/theme.lua
+++ b/lua/material/theme.lua
@@ -392,7 +392,7 @@ theme.loadPlugins = function()
 	if config.plugins.nvim_tree then
 		plugins.NvimTreeNormal =						{ fg = colors.fg, bg = colors.sidebar }
 		plugins.NvimTreeNormalNC =						{ fg = colors.fg, bg = colors.bg_nc }
-		plugins.NvimTreeRootFolder =                    { fg = colors.accent, bg = colors.sidebar }
+		plugins.NvimTreeRootFolder =                    { fg = colors.accent }
 		plugins.NvimTreeFolderName=                     { fg = colors.blue, bold = true }
 		plugins.NvimTreeFolderIcon=                     { link = "NvimTreeFolderName" }
 		plugins.NvimTreeEmptyFolderName=                { fg = colors.gray }
@@ -407,6 +407,7 @@ theme.loadPlugins = function()
 		plugins.NvimTreeMarkdownFile =                  { fg = colors.pink }
 		plugins.NvimTreeExecFile =                      { link = "NvimTreeGitNew" }
 		plugins.NvimTreeSpecialFile =                   { fg = colors.purple }
+		plugins.NvimTreeSignColumn =                    { link = "SignColumn" }
 	end
 
 	-- Sidebar.nvim


### PR DESCRIPTION
RootFolder and SignColumn were still not respecting non_current_window contrast option. Fixed by removing the explicitly set background for the former and linking the latter to global SignColumn.

Before:
![image](https://user-images.githubusercontent.com/2804020/193842942-916d016f-3618-47cb-adcb-2cb9e68f9386.png)

After:
![image](https://user-images.githubusercontent.com/2804020/193843035-25b8b98f-58f7-4172-9381-5dd160297f98.png)

Partly fixes #113