### PR TITLE
fix(highlights): Add DiffAdded and DiffRemoved highlights

### DIFF
--- a/lua/material/highlights/init.lua
+++ b/lua/material/highlights/init.lua
@@ -147,8 +147,10 @@ M.main_highlights.editor = function()
         LineNr           = { fg = e.line_numbers },
         CursorLineNr     = { fg = e.accent },
         DiffAdd          = { fg = g.added, reverse = true },
+        DiffAdded        = { fg = g.added },
         DiffChange       = { fg = g.modified },
         DiffDelete       = { fg = g.removed, reverse = true },
+        DiffRemoved      = { fg = g.removed },
         DiffText         = { fg = g.modified, reverse = true },
         ModeMsg          = { fg = e.accent }, -- 'showmode' message (e.g., "-- INSERT -- ")
         NonText          = { fg = e.disabled },


### PR DESCRIPTION
These both highlight groups were missing prior, which caused various git plugins to lose highlighting for diffs.

Before:
<img width="506" alt="image" src="https://user-images.githubusercontent.com/30572790/196754320-92f2234d-67fd-45c0-9846-80da2cfc0a96.png">

After:
<img width="508" alt="image" src="https://user-images.githubusercontent.com/30572790/196754495-919f8c54-421b-49cb-b734-677631a70789.png">

Maybe this also broke in my setup somewhere and I have to link these highlight groups myself?