### PR TITLE
Fix custom_highlights

### DIFF
--- a/lua/material/util/init.lua
+++ b/lua/material/util/init.lua
@@ -87,8 +87,8 @@ local load_async = function()
     end
 
     -- load user defined higlights
-    if type(settings.cusom_highlights) == "table" then
-        apply_highlights(settings.cusom_highlights)
+    if type(settings.custom_highlights) == "table" then
+        apply_highlights(settings.custom_highlights)
     end
 
     -- apply contrast to the terminal and user defined filetypes


### PR DESCRIPTION
I noticed custom_highlights were no longer working and saw a couple issues reporting the same. I believe this was just a simple typo where the plugin is looking for cusom_highlights instead of custom_highlights.

 - fix #126 
 - fix #124