### PR TITLE
Add @text.diff.* and @attribute treesitter tags

### DIFF
--- a/lua/material/highlights/init.lua
+++ b/lua/material/highlights/init.lua
@@ -108,6 +108,10 @@ M.main_highlights.treesitter = function()
             ["@string.regex"]   = { fg = m.yellow },
             ["@string.special"] = { fg = e.fg_dark },
 
+            ["@text.diff.add"]    = { link = "DiffAdd" },
+            ["@text.diff.delete"] = { link = "DiffDelete" },
+            ["@attribute"]        = { link = "DiffChange" },
+
             -- ["@structure"]             = { fg = s.type },
             -- ["@storageclass"]          = { fg = m.cyan },
 
@@ -185,10 +189,10 @@ M.main_highlights.editor = function()
         FoldColumn       = { fg = m.blue },
         LineNr           = { fg = e.line_numbers },
         CursorLineNr     = { fg = e.accent },
-        DiffAdd          = { fg = g.added, reverse = true },
+        DiffAdd          = { fg = g.added },
         DiffChange       = { fg = g.modified },
-        DiffDelete       = { fg = g.removed, reverse = true },
-        DiffText         = { fg = g.modified, reverse = true },
+        DiffDelete       = { fg = g.removed },
+        DiffText         = { fg = g.modified },
         ModeMsg          = { fg = e.accent }, -- 'showmode' message (e.g., "-- INSERT -- ")
         NonText          = { fg = e.disabled },
         SignColumn       = { fg = e.fg },
@@ -243,8 +247,8 @@ M.async_highlights.editor = function()
         WildMenu      = { fg = m.orange, bold = true }, -- current match in 'wildmenu' completion
         -- VertSplit     = { fg = e.vsplit },
         WinSeparator  = { fg = e.vsplit },
-        diffAdded     = { fg = g.added, reverse = true },
-        diffRemoved   = { fg = g.removed, reverse = true },
+        diffAdded     = { fg = g.added },
+        diffRemoved   = { fg = g.removed },
         -- ToolbarLine   = { fg = e.fg, bg = e.bg_alt },
         -- ToolbarButton = { fg = e.fg, bold = true },
         -- NormalMode       = { fg = e.disabled }, -- Normal mode message in the cmdline

--- a/lua/material/highlights/init.lua
+++ b/lua/material/highlights/init.lua
@@ -189,10 +189,10 @@ M.main_highlights.editor = function()
         FoldColumn       = { fg = m.blue },
         LineNr           = { fg = e.line_numbers },
         CursorLineNr     = { fg = e.accent },
-        DiffAdd          = { fg = g.added },
+        DiffAdd          = { fg = g.added, reverse = true },
         DiffChange       = { fg = g.modified },
-        DiffDelete       = { fg = g.removed },
-        DiffText         = { fg = g.modified },
+        DiffDelete       = { fg = g.removed, reverse = true },
+        DiffText         = { fg = g.modified, reverse = true },
         ModeMsg          = { fg = e.accent }, -- 'showmode' message (e.g., "-- INSERT -- ")
         NonText          = { fg = e.disabled },
         SignColumn       = { fg = e.fg },
@@ -247,8 +247,8 @@ M.async_highlights.editor = function()
         WildMenu      = { fg = m.orange, bold = true }, -- current match in 'wildmenu' completion
         -- VertSplit     = { fg = e.vsplit },
         WinSeparator  = { fg = e.vsplit },
-        diffAdded     = { fg = g.added },
-        diffRemoved   = { fg = g.removed },
+        diffAdded     = { fg = g.added, reverse = true },
+        diffRemoved   = { fg = g.removed, reverse = true },
         -- ToolbarLine   = { fg = e.fg, bg = e.bg_alt },
         -- ToolbarButton = { fg = e.fg, bold = true },
         -- NormalMode       = { fg = e.disabled }, -- Normal mode message in the cmdline


### PR DESCRIPTION
I added three handlers that are used inside diff files.

I also removed the `reverse = true` from `Diff*` and `diff*` highlight groups. The screenshot below is for `DiffAdd` with `reverse = true` and `DiffDelete` without:
<img width="436" alt="Screenshot 2022-10-24 at 07 21 47" src="https://user-images.githubusercontent.com/26097838/197453827-c7fa3bc3-1fef-41d0-9075-e17a28e99617.png">

The final result:
<img width="425" alt="Screenshot 2022-10-24 at 07 23 51" src="https://user-images.githubusercontent.com/26097838/197453890-4a94f88a-20f6-4861-8197-e85f9f015b8d.png">

Update:
I assume that the look of `reverse = true` is bad due to my config but without those tabs/spaces colouring it should be fine. I've also seen a PR when you asked someone to add `reverse = true` that is why I added `reverse = true` back to the code.