### PR TITLE
feat(highlights): add highlight for code lenses

### DIFF
--- a/lua/material/highlights/init.lua
+++ b/lua/material/highlights/init.lua
@@ -304,6 +304,7 @@ M.async_highlights.load_lsp = function()
         LspReferenceText           = { bg = e.selection }, -- used for highlighting "text" references
         LspReferenceRead           = { link = "LspReferenceText" }, -- used for highlighting "read" references
         LspReferenceWrite          = { link = "LspReferenceText" }, -- used for highlighting "write" references
+        LspCodeLens                = { link = "DiagnosticHint" },
     }
 
     return lsp_hls


### PR DESCRIPTION
Hi.

Amazing plugin! With the customisability and nice defaults I'm really close to getting the color theme I've always dreamed of.

The highlight group,  `LspCodeLens` is fairly new and hasn't been documented for very long.
I thought I might add a highlight here, since the default is the same as the regular foreground colour, which is quite ugly and confusing.