### PR TITLE
Fix diff filetype

### DIFF
--- a/lua/material/highlights/init.lua
+++ b/lua/material/highlights/init.lua
@@ -250,8 +250,8 @@ M.async_highlights.editor = function()
         WildMenu      = { fg = m.orange, bold = true }, -- current match in 'wildmenu' completion
         VertSplit     = { fg = e.vsplit },
         WinSeparator  = { fg = e.vsplit },
-        diffAdded     = { fg = g.added, reverse = true },
-        diffRemoved   = { fg = g.removed, reverse = true },
+        diffAdded     = { fg = g.added },
+        diffRemoved   = { fg = g.removed },
         -- ToolbarLine   = { fg = e.fg, bg = e.bg_alt },
         -- ToolbarButton = { fg = e.fg, bold = true },
         -- NormalMode       = { fg = e.disabled }, -- Normal mode message in the cmdline


### PR DESCRIPTION
Diffing two files (with `nvim -d file1 file2`) should use the `reverse = true` flags, but viewing a diff file (with `nvim patch.diff`) should not.  This is especially important when viewing a diff of two diff files, i.e., `nvim -d patch1.diff patch2.diff`.