### PR TITLE
fix(neogit): Neogit popup switch not highlighted. Fix #153

### DIFF
--- a/lua/material/highlights/init.lua
+++ b/lua/material/highlights/init.lua
@@ -51,7 +51,7 @@ M.main_highlights.syntax = function()
         -- PreCondit   = { link = "Macro" },
         -- Typedef        = { link = "Operator" },
         Special        = { fg = m.cyan },
-        SpecialChar    = { fg = e.disabled },
+        SpecialChar    = { fg = m.red },
         Tag            = { fg = m.red },
         Delimiter      = { fg = s.operator }, -- ;
         Debug          = { fg = m.red },

--- a/lua/material/highlights/plugins/neogit.lua
+++ b/lua/material/highlights/plugins/neogit.lua
@@ -9,11 +9,20 @@ M.load = function()
     local plugin_hls = {
         NeogitBranch               = { fg = m.paleblue },
         NeogitRemote               = { fg = m.purple },
+
         NeogitHunkHeader           = { fg = e.fg, bg = e.highlight },
         NeogitHunkHeaderHighlight  = { fg = m.blue, bg = e.contrast },
+
+        NeogitDiffAdd              = { fg = m.green },
+        NeogitDiffDelete           = { fg = m.red },
+
         NeogitDiffContextHighlight = { fg = e.fg_dark, bg = e.contrast },
         NeogitDiffDeleteHighlight  = { fg = m.red },
         NeogitDiffAddHighlight     = { fg = m.yellow },
+
+        NeogitNotificationInfo     = { fg = m.paleblue },
+        NeogitNotificationWarning  = { fg = m.yellow },
+        NeogitNotificationError    = { fg = m.red },
     }
 
     return plugin_hls


### PR DESCRIPTION
Fix #153 and add the rest neogit color group.

```diff
diff --git a/lua/material/highlights/plugins/neogit.lua b/lua/material/highlights/plugins/neogit.lua
index 752c075..0445309 100644
--- a/lua/material/highlights/plugins/neogit.lua
+++ b/lua/material/highlights/plugins/neogit.lua
@@ -9,11 +9,20 @@ M.load = function()
     local plugin_hls = {
         NeogitBranch               = { fg = m.paleblue },
         NeogitRemote               = { fg = m.purple },
+
         NeogitHunkHeader           = { fg = e.fg, bg = e.highlight },
         NeogitHunkHeaderHighlight  = { fg = m.blue, bg = e.contrast },
+
+        NeogitDiffAdd              = { fg = m.green },
+        NeogitDiffDelete           = { fg = m.red },
+
         NeogitDiffContextHighlight = { fg = e.fg_dark, bg = e.contrast },
         NeogitDiffDeleteHighlight  = { fg = m.red },
         NeogitDiffAddHighlight     = { fg = m.yellow },
+
+        NeogitNotificationInfo     = { fg = m.paleblue },
+        NeogitNotificationWarning  = { fg = m.yellow },
+        NeogitNotificationError    = { fg = m.red },
     }
 
     return plugin_hls
```