### PR TITLE
adding builtin vim.ui.select if telescope not found

### DIFF
--- a/lua/material/functions/telescope_styles.lua
+++ b/lua/material/functions/telescope_styles.lua
@@ -1,55 +1,66 @@
-local pickers      = require "telescope.pickers"
-local finders      = require "telescope.finders"
-local sorters      = require "telescope.sorters"
-local actions      = require "telescope.actions"
-local action_state = require "telescope.actions.state"
-
+local ok, telescope = pcall(require, "telescope")
 local M = {}
 
----table that defines the look and layout of the prompt
-local center_prompt = {
-	layout_strategy = "vertical",
-	layout_config = {
-		height = 10,
-		width = 0.3,
-		prompt_position = "top",
-	},
-	sorting_strategy = "ascending",
-}
-
----takes the current entry and switches to that style
----@param prompt_bufnr number buffer number of the prompt
-local function enter(prompt_bufnr)
-	local selected = action_state.get_selected_entry()
-	vim.g.material_style = selected[1]
-	vim.cmd "colorscheme material"
-	actions.close(prompt_bufnr)
-end
-
----options to call telescope with
-local opts = {
-	finder = finders.new_table {
-		"darker",
-		"lighter",
-		"deep ocean",
-		"oceanic",
-		"palenight"
-	},
-	prompt_title = "Material",
-	results_title = "styles",
-	sorter = sorters.get_fzy_sorter({}),
-	borderchars = { "─", "│", "─", "│", "╭", "╮", "╯", "╰" },
-	attach_mappings = function (_, map)
-		map("i", "<CR>", enter)
-		map("n", "<CR>", enter)
-		return true
+if not ok then
+	M.find = function()
+		local styles = { "darker", "lighter", "deep ocean", "oceanic", "palenight" }
+		vim.ui.select(styles, { prompt = "Material" }, function(style)
+			vim.g.material_style = style
+			vim.cmd("colorscheme material")
+		end)
 	end
-}
+else
+	local pickers = require("telescope.pickers")
+	local finders = require("telescope.finders")
+	local sorters = require("telescope.sorters")
+	local actions = require("telescope.actions")
+	local action_state = require("telescope.actions.state")
 
----find styles using telesope
-M.find = function ()
-	local colors = pickers.new(center_prompt, opts)
-	colors:find()
+	---table that defines the look and layout of the prompt
+	local center_prompt = {
+		layout_strategy = "vertical",
+		layout_config = {
+			height = 10,
+			width = 0.3,
+			prompt_position = "top",
+		},
+		sorting_strategy = "ascending",
+	}
+
+	---takes the current entry and switches to that style
+	---@param prompt_bufnr number buffer number of the prompt
+	local function enter(prompt_bufnr)
+		local selected = action_state.get_selected_entry()
+		vim.g.material_style = selected[1]
+		vim.cmd("colorscheme material")
+		actions.close(prompt_bufnr)
+	end
+
+	---options to call telescope with
+	local opts = {
+		finder = finders.new_table({
+			"darker",
+			"lighter",
+			"deep ocean",
+			"oceanic",
+			"palenight",
+		}),
+		prompt_title = "Material",
+		results_title = "styles",
+		sorter = sorters.get_fzy_sorter({}),
+		borderchars = { "─", "│", "─", "│", "╭", "╮", "╯", "╰" },
+		attach_mappings = function(_, map)
+			map("i", "<CR>", enter)
+			map("n", "<CR>", enter)
+			return true
+		end,
+	}
+
+	---find styles using telesope
+	M.find = function()
+		local colors = pickers.new(center_prompt, opts)
+		colors:find()
+	end
 end
 
 return M


### PR DESCRIPTION
i've recently configured my setup using `mini.pick` modules and currently don't use `telescope`. to enhance user experience, i propose integrating with `vim.ui.select` when telescope is not installed, avoiding potential errors. this change benefits users of `fzf-lua` as well. also, it's worth noting the positive impact when `dressing.nvim` is installed. 
thank you.

belo photo with vim.ui.select (dressing installed)
<img width="436" alt="Screen Shot 2023-11-15 at 10 35 15 PM" src="https://github.com/marko-cerovac/material.nvim/assets/105807570/e5689755-077f-420e-a5a2-ddcba529968e">
