### PR TITLE
Cyan markdown headings

### DIFF
--- a/lua/material/highlights/init.lua
+++ b/lua/material/highlights/init.lua
@@ -157,6 +157,7 @@ M.main_highlights.treesitter = function()
             ["@markup.strong"]            = { bold = true },
             -- ["@markup.strikethrough"]     = { style = { "strikethrough" } },
             ["@markup.title"]             = { fg = m.cyan, bold = true },
+            ["@markup.heading"]           = { fg = m.cyan, bold = true },
             ["@markup.literal"]           = { fg = m.green },
             ["@markup.link"]              = { link = "Tag" }, -- text references, footnotes, citations, etc.
             ["@markup.link.url"]          = { fg = e.link }, -- urls, links and emails


### PR DESCRIPTION
I don't know if you agree but I like the headings in markdown to have some highlight.

Before:
![image](https://github.com/marko-cerovac/material.nvim/assets/56983005/c2dc0501-7d34-4ec1-aa6d-951a0d7846bc)

After:
![image](https://github.com/marko-cerovac/material.nvim/assets/56983005/50ae62cb-bc79-4b07-815f-afab86a9abe0)

