### PR TITLE
Dynamic custom highlights

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,22 @@ material.setup{
         LineNr = { bg = '#FF0000' },
         CursorLine = { fg = colors.editor.constrast , underline = true },
 
+        -- Dynamically override highlight groups with functions to ensure colors are
+        -- updated when changing styles at runtime
+        TabLine = function(colors, _)
+            return {
+                fg = colors.main.gray,
+                italic = true,
+            }
+        end,
+        TabLineSel = function(_, highlights)
+            return vim.tbl_extend(
+                "force",
+                highlights.main_highlights.editor()["TabLineSel"],
+                { bold = true }
+            )
+        end,
+
         -- This is a list of possible values
         YourHighlightGroup = {
             fg = "#SOME_COLOR", -- foreground color

--- a/doc/material.nvim.txt
+++ b/doc/material.nvim.txt
@@ -305,7 +305,17 @@ require('material').setup({
     ...
     custom_highlights = {
         Function = { fg = "#00FF00", bg = "#FF0000", italic = true },
-        TelescopePromptBorder = { fg = "#0A0A0A", bg = "#000000", bold = true }
+        TelescopePromptBorder = { fg = "#0A0A0A", bg = "#000000", bold = true },
+        TabLine = function(colors, _)
+            return { fg = colors.main.gray, italic = true, }
+        end,
+        TabLineSel = function(_, highlights)
+            return vim.tbl_extend(
+                "force",
+                highlights.main_highlights.editor()["TabLineSel"],
+                { bold = true }
+            )
+        end
     }
     ...
 })

--- a/lua/material/util/init.lua
+++ b/lua/material/util/init.lua
@@ -1,13 +1,24 @@
 local highlights = require "material.highlights"
+local colors = require "material.colors"
 local settings   = require "material.util.config".settings
 
 local M = {}
 
 ---apply highlights for a given table
----@param highlights table highlight group names and their values
-local apply_highlights = function(highlights)
-    for name, values in pairs(highlights) do
-        vim.api.nvim_set_hl(0, name, values)
+---@param extra_highlights table highlight group names and their values
+local apply_highlights = function(extra_highlights)
+    -- To prevent the user accidentally modifying global settings this way
+    local copy_colors = vim.deepcopy(colors)
+    local copy_highlights = vim.deepcopy(highlights)
+
+    for name, values in pairs(extra_highlights) do
+        local hl_val = {}
+        if type(values) == "table" then
+            hl_val = values
+        elseif type(values) == "function" then
+            hl_val = values(copy_colors, copy_highlights)
+        end
+        vim.api.nvim_set_hl(0, name, hl_val)
     end
 end
 

--- a/lua/material/util/init.lua
+++ b/lua/material/util/init.lua
@@ -16,7 +16,22 @@ local apply_highlights = function(extra_highlights)
         if type(values) == "table" then
             hl_val = values
         elseif type(values) == "function" then
-            hl_val = values(copy_colors, copy_highlights)
+            ret = values(copy_colors, copy_highlights)
+            if type(ret) == "table" then
+                hl_val = ret
+            else
+                vim.notify_once("highlight function for highlight-group '" ..
+                    name .. "' returned '" .. type(ret) .. "', expected table",
+                    vim.log.levels.ERROR,
+                    { title = "material.nvim" }
+                )
+            end
+        else
+            vim.notify_once("cannot create custom highlight '" .. name ..
+                "' from value of type '" .. type(values) .. "'",
+                vim.log.levels.ERROR,
+                { title = "material.nvim" }
+            )
         end
         vim.api.nvim_set_hl(0, name, hl_val)
     end

--- a/lua/material/util/init.lua
+++ b/lua/material/util/init.lua
@@ -7,16 +7,12 @@ local M = {}
 ---apply highlights for a given table
 ---@param extra_highlights table highlight group names and their values
 local apply_highlights = function(extra_highlights)
-    -- To prevent the user accidentally modifying global settings this way
-    local copy_colors = vim.deepcopy(colors)
-    local copy_highlights = vim.deepcopy(highlights)
-
     for name, values in pairs(extra_highlights) do
         local hl_val = {}
         if type(values) == "table" then
             hl_val = values
         elseif type(values) == "function" then
-            ret = values(copy_colors, copy_highlights)
+            local ret = values(colors, highlights)
             if type(ret) == "table" then
                 hl_val = ret
             else


### PR DESCRIPTION
Hello,

yesterday, while working in the bright sun, I tried out the light theme variant for the first time. While it makes working in the sun comfortable, I noticed that it doesn't go well at all with my tabline plugin. That's because I overrode the `TabLine*` highlight groups myself, because I wanted their colors changed slightly.

I did this with a config snippet as follows:

```lua
                    TabLine = {
                        fg = colors.main.gray,
                        bg = colors.editor.bg,
                        italic = true
                    },
```

Where `colors` is defined further up as `local colors = require("material.colors");`. Of course, in this case, when switching themes, the change in colors isn't recognized, since `colors` is a local variable in my setup function.

To change that I patched the setup function `apply_highlights` to accept functions as values for custom highlights. In my current design, these functions receive as argument the themes colors and the themes highlights. This would allow me to rewrite my above example as either:

```lua
TabLine = function(col, _)
    return {
        fg = col.main.gray,
        bg = col.editor.bg,
        italic = true
    }
end,
```

or

```lua
TabLine = function(_, hl)
    return vim.tbl_extend("force", hl.main_highlights.editor().Tabline, { italic = true })
end
```

where either approach results in theme colors being applied correctly when changing themes at runtime.

If you prefer, I can also change the design to e.g. make the value of `custom_highlights` in the config a function, which must return a table with all the custom highlight groups (similar to how `custom_colors` works today).

If you'd like to include this patch, I'll update the docs and include these examples there so users can discover the change more easily. Let me know what you think!