### PR TITLE
Add support for colorful-winsep.nvim

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,8 @@ require('material').setup({
 
     plugins = { -- Uncomment the plugins that you use to highlight them
         -- Available plugins:
-        -- "coc"
+        -- "coc",
+        -- "colorful-winsep",
         -- "dap",
         -- "dashboard",
         -- "eyeliner",

--- a/doc/material.nvim.txt
+++ b/doc/material.nvim.txt
@@ -224,6 +224,7 @@ This is an example of the setup function with the default values:
           To apply the theme to a plugin, set it in this table
           Available plugins:
             - coc
+            - colorful-winsep
             - dap
             - dashboard
             - eyeliner

--- a/lua/material/highlights/plugins/colorful-winsep.lua
+++ b/lua/material/highlights/plugins/colorful-winsep.lua
@@ -1,0 +1,21 @@
+local colors = require "material.colors"
+
+local fg = colors.editor.selection
+local bg = colors.editor.bg
+
+local M = {}
+
+M.load = function()
+    local plugin_hls = {
+        NvimSeparator = {
+            fg = fg,
+            bg = bg,
+        },
+    }
+
+    return plugin_hls
+end
+
+M.async = true
+
+return M


### PR DESCRIPTION
https://github.com/nvim-zh/colorful-winsep.nvim

Here is how the plugin looks with this PR. The active split is the bottom right one. Two colorcolumns are also visible.

<img width="1512" alt="Screenshot 2024-05-01 at 01 44 39" src="https://github.com/marko-cerovac/material.nvim/assets/11805218/3957d386-0dde-46b2-ad9c-1df935fa8608">
