### PR TITLE
Add parameter style to syntax

### DIFF
--- a/lua/material/colors/init.lua
+++ b/lua/material/colors/init.lua
@@ -193,7 +193,7 @@ colors.syntax.keyword  = colors.main.purple
 colors.syntax.value    = colors.main.orange
 colors.syntax.operator = colors.main.cyan
 colors.syntax.fn       = colors.main.blue
-colors.syntax.parameter = colors.main.darkorange
+colors.syntax.parameter = colors.main.paleblue
 colors.syntax.string   = colors.main.green
 colors.syntax.type     = colors.main.purple
 


### PR DESCRIPTION
Something I noticed with this colorscheme is that it does not differentiate the incoming parameters in function calls (see [hlargs.nvim](https://github.com/m-demare/hlargs.nvim) for an example of what I mean). With lsp semantic tokens, we have the ability to do this so I added a new syntax group (parameter) and updated the `@variable.parameter` highlight group to point at this new syntax group instead.

The end result is something like this
![image](https://github.com/user-attachments/assets/4201583f-ff3c-4a0b-b342-ddf709d05873)

As opposed to this
![image](https://github.com/user-attachments/assets/277453ef-2d7f-4e8d-9da8-6932702b75ac)

Note, I am not sold on using `darkorange` for parameter colors, I just used it for this PR as a way to make the parameters stand out. I am more than happy to change this color to whatever is requested :)

A last note, I have no idea if this PR is welcome or not, I typically discuss incoming PRs beforehand but this one was pretty low hanging fruit and something I personally wanted so I figured I would toss this over the fence :)