### PR TITLE
fix(plugin): neotest hlgroups

### DIFF
--- a/lua/material/highlights/plugins/neotest.lua
+++ b/lua/material/highlights/plugins/neotest.lua
@@ -10,11 +10,11 @@ M.load = function()
         NeotestAdapterName = { fg = m.darkred },
         NeotestBorder = { fg = e.border },
         NeotestDir = { fg = m.blue },
-        NeotestExpandMarker = { fg = e.contrast },
+        NeotestExpandMarker = { link = "NeotestIndent" }, -- shown immediately after indent
         NeotestFailed = { link = "DiagnosticError" },
         NeotestFile = { fg = m.blue },
         NeotestFocused = { bold = true, underline = true },
-        NeotestIndent = { fg = e.contrast },
+        NeotestIndent = { fg = e.line_numbers }, -- aka tree symbols
         NeotestMarked = { fg = m.darkyellow, bold = true },
         NeotestNamespace = { fg = m.purple },
         NeotestPassed = { fg = m.green },

--- a/lua/material/highlights/plugins/neotest.lua
+++ b/lua/material/highlights/plugins/neotest.lua
@@ -8,6 +8,7 @@ local M = {}
 M.load = function()
     local plugin_hls = {
         NeotestAdapterName = { fg = m.darkred },
+        NeotestBorder = { fg = e.border },
         NeotestDir = { fg = m.blue },
         NeotestExpandMarker = { fg = e.contrast },
         NeotestFailed = { link = "DiagnosticError" },
@@ -22,6 +23,7 @@ M.load = function()
         NeotestTarget = { fg = m.red },
         NeotestTest = { fg = e.fg },
         NeotestUnknown = { fg = e.fg },
+        NeotestWatching = { link = "DiagnosticInfo" },
         NeotestWinSelect = { fg = m.blue, bold = true },
     }
 

--- a/lua/material/highlights/plugins/neotest.lua
+++ b/lua/material/highlights/plugins/neotest.lua
@@ -7,22 +7,22 @@ local M = {}
 
 M.load = function()
     local plugin_hls = {
-        NeotestPassed = { fg = m.green },
+        NeotestAdapterName = { fg = m.darkred },
+        NeotestDir = { fg = m.blue },
+        NeotestExpandMarker = { fg = e.contrast },
         NeotestFailed = { link = "DiagnosticError" },
+        NeotestFile = { fg = m.blue },
+        NeotestFocused = { bold = true, underline = true },
+        NeotestIndent = { fg = e.contrast },
+        NeotestMarked = { fg = m.darkyellow, bold = true },
+        NeotestNamespace = { fg = m.purple },
+        NeotestPassed = { fg = m.green },
         NeotestRunning = { fg = m.yellow },
         NeotestSkipped = { link = "DiagnosticHint" },
-        NeotestTest = { fg = e.fg },
-        NeotestNamespace = { fg = m.purple },
-        NeotestFocused = { bold = true, underline = true },
-        NeotestFile = { fg = m.blue },
-        NeotestDir = { fg = m.blue },
-        NeotestIndent = { fg = e.contrast },
-        NeotestExpandMarker = { fg = e.contrast },
-        NeotestAdapterName = { fg = m.darkred },
-        NeotestWinSelect = { fg = m.blue, bold = true },
-        NeotestMarked = { fg = m.darkyellow, bold = true },
         NeotestTarget = { fg = m.red },
+        NeotestTest = { fg = e.fg },
         NeotestUnknown = { fg = e.fg },
+        NeotestWinSelect = { fg = m.blue, bold = true },
     }
 
     return plugin_hls


### PR DESCRIPTION
- Added missing hlgroups `NeotestBorder` and `NeotestWatching`
- Fixed tree symbol hlgroups
  - The previous colors were unlegible on all colorscheme variants[^1]
  - Changed them to match line numbers since that's what Snacks uses
    for the same purpose and it looks decent on all variants[^2]
- Sorted all the Neotest hlgroups

[^1]: https://github.com/user-attachments/assets/9660e4d8-3dab-41d8-980d-2a21c5234ca1
[^2]: https://github.com/user-attachments/assets/35e15aa2-28b3-42cf-ab5e-6bd3e103e904

