### PR TITLE
changed hl groups to link to Keyword instead of @ keyword

### DIFF
--- a/lua/material/highlights/init.lua
+++ b/lua/material/highlights/init.lua
@@ -98,7 +98,7 @@ M.main_highlights.treesitter = function()
             ["@type.qualifier"]   = { fg = m.cyan },
 
             ["@variable"]           = { link = "Identifier" },
-            ["@variable.builtin"]   = { link = "@keyword" },
+            ["@variable.builtin"]   = { link = "Keyword" },
             -- ["@field"]              = { fg = e.fg_dark },
             ["@property"]           = { fg = e.fg_dark },
             ["@variable.parameter"] = { link = "Identifier" },
@@ -115,12 +115,12 @@ M.main_highlights.treesitter = function()
 
             ["@constructor"]      = { fg = m.blue },
 
-            ["@keyword"]           = { fg = m.cyan },
-            ["@keyword.coroutine"] = { fg = m.cyan, italic = true },
-            ["@keyword.operator"]  = { link = "@keyword" },
-            ["@keyword.return"]    = { link = "@keyword" },
-            ["@keyword.function"]  = { link = "@keyword" },
-            ["@keyword.export"]    = { link = "@keyword" },
+            ["@keyword"]           = { link = "Keyword" },
+            ["@keyword.coroutine"] = { link = "Keyword" },
+            ["@keyword.operator"]  = { link = "Keyword" },
+            ["@keyword.return"]    = { link = "Keyword" },
+            ["@keyword.function"]  = { link = "Keyword" },
+            ["@keyword.export"]    = { link = "Keyword" },
 
             ["@keyword.conditional"]       = { link = "Conditional" },
             ["@keyword.repeat"]            = { link = "Repeat" },


### PR DESCRIPTION
Just so you know I have no experience in contributing to neovim plugins but it is my daily editor.

I could change custom_colors for everything but keywords (using colors.syntax.keyword = ...). It seems that keywords are the only thing that doesn't follow hl group from plugin (`Keyword` in this case). They rather follow `@keyword` group (from Treesitter) which is defined as cyan color and stays that way no matter the configuration (removing `@keyword` hl group after start works too).

If I'm spitting nonsense please correct me. Maybe that's just a skill issue on my side. I just want my color for keywords